### PR TITLE
Fix README language link references

### DIFF
--- a/README.ZH.md
+++ b/README.ZH.md
@@ -2,7 +2,7 @@
 
 <p align="right">
   <a href="README.md">English Version</a> |
-  <a href="README.zh.md">中文版</a>
+  <a href="README.ZH.md">中文版</a>
 </p>
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🔍 FuncTrace Analyzer
 
 <p align="right">
-  <a href="README.zh.md">中文版</a> |
+  <a href="README.ZH.md">中文版</a> |
   <a href="README.md">English Version</a>
 </p>
 


### PR DESCRIPTION
Update README files to use consistent and correct language link references, changing lowercase 'zh.md' to uppercase 'ZH.md' in both English and Chinese README files.